### PR TITLE
Calendar fixes

### DIFF
--- a/calendar_generator/pdf.py
+++ b/calendar_generator/pdf.py
@@ -2,7 +2,6 @@
 
 import os
 from dataclasses import dataclass
-import functools
 
 from typing import Optional, List
 
@@ -136,6 +135,8 @@ class CalendarGenerator:
 
     style: Style
     layout: Layout
+
+    minimum_row_count_calculation: float = 0
 
     # Used to track how much vertical space we've used
     _used_top_space: float = 0

--- a/calendar_generator/pdf.py
+++ b/calendar_generator/pdf.py
@@ -110,17 +110,17 @@ class Layout:
         space_for_rows = self.inner_height - (row_pad * (row_count - 1))
         row_height = space_for_rows / row_count
 
-        for col_index in range(col_count):
-            col_offset = self.left_margin + col_index * (col_width + col_pad)
+        for row_index in range(row_count):
+            # We're indexing from the top but drawing from the bottom, so this has to do some inversion
+            row_offset = self.inner_height - row_height * (row_index+1) - row_pad * row_index + self.bottom_margin
 
-            for row_index in range(row_count):
-                # We're indexing from the top but drawing from the bottom, so this has to do some inversion
-                row_offset = self.inner_height - row_height * (row_index+1) - row_pad * row_index + self.bottom_margin
+            for col_index in range(col_count):
+                col_offset = self.left_margin + col_index * (col_width + col_pad)
 
                 style = Layout(width=col_width, height=row_height,
-                                  top_margin=0, bottom_margin=0,
-                                  left_margin=0, right_margin=0,
-                                  x_pos=col_offset, y_pos=row_offset)
+                               top_margin=0, bottom_margin=0,
+                               left_margin=0, right_margin=0,
+                               x_pos=col_offset, y_pos=row_offset)
 
                 out.append(style)
 

--- a/calendar_generator/views.py
+++ b/calendar_generator/views.py
@@ -336,7 +336,7 @@ class PDFOnePage(View):
             grid_generator = grids.CalendarGridGenerator(date_letter_map, label_map, start_date, end_date)
             grid = grid_generator.get_grid()
 
-            generator = pdf.CalendarGenerator(pdf_canvas, grid, style, layout)
+            generator = pdf.CalendarGenerator(pdf_canvas, grid, style, layout, minimum_row_count_calculation=5)
             generator.draw()
 
         pdf_canvas.save()


### PR DESCRIPTION
- Fix one-page calendar draw order
- Pre-calculate all variables when drawing an individual calendar
- Keep titles the same size on one-page calendar draw (closes #40)