### PR TITLE
Fix removal object lookup

### DIFF
--- a/blackbaud/sync.py
+++ b/blackbaud/sync.py
@@ -281,7 +281,7 @@ def _inner_sync(
 
     # Only soft delete
     for source_id in to_remove:
-        obj = sis_data[source_id]
+        obj = objs_by_id[source_id]
         if obj.active:
             obj.active = False
             obj.save()


### PR DESCRIPTION
When removing (deactivating) objects, we were looking them up in the SIS data and not the object data. Fix it.