### PR TITLE
Check for active on student and teacher enrollments

### DIFF
--- a/blackbaud/advising.py
+++ b/blackbaud/advising.py
@@ -78,6 +78,7 @@ def get_advisees(
             if (
                 teacher_enrollment.begin_date <= as_of
                 and as_of <= teacher_enrollment.end_date
+                and teacher_enrollment.active
             ):
                 for student_enrollment in section.student_enrollments.all():
                     assert isinstance(student_enrollment, StudentEnrollment)
@@ -85,6 +86,7 @@ def get_advisees(
                     if (
                         student_enrollment.begin_date <= as_of
                         and as_of <= student_enrollment.end_date
+                        and student_enrollment.active
                     ):
                         pairs.add(
                             AdviseePair(


### PR DESCRIPTION
Advisees were showing up on both old and new advisors. This is because I was ignoring the "active" flag on both student and teacher enrollments to advisory classes, though only students mattered in this particular case.