### PR TITLE
Remove Uvicorn

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,3 +31,4 @@ venv
 .vscode
 .idea
 scratch
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ COPY . ./
 RUN python manage.py collectstatic --no-input
 EXPOSE 8000
 
-CMD ["gunicorn", "--worker-tmp-dir", "/dev/shm", "--bind", ":8000", "core.asgi:application", "-k", "uvicorn.workers.UvicornWorker"]
+CMD ["gunicorn", "--worker-tmp-dir", "/dev/shm", "--bind", ":8000", "core.wsgi:application"]

--- a/enrichment/slots.py
+++ b/enrichment/slots.py
@@ -357,9 +357,9 @@ class GridGenerator:
                 only_available_on_ids.add(SlotID(db_slot.pk))
 
             for db_override in obj.location_overrides.all():
-                location_overrides_by_id[SlotID(db_override.slot_id)] = (
-                    db_override.location
-                )
+                location_overrides_by_id[
+                    SlotID(db_override.slot_id)
+                ] = db_override.location
 
             teacher = _teacher_to_grid(obj.teacher)
             exclude_from = {

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:50c7a9270849772f86c33056472a0e0f98da884f995c4406c2ebf3f48d806aff"
+content_hash = "sha256:cd306d0abf5198d86b356e35e9bc8f8a3524dd2ecd901590d865795da8b2a002"
 
 [[package]]
 name = "asgiref"
@@ -132,7 +132,7 @@ name = "click"
 version = "8.1.7"
 requires_python = ">=3.7"
 summary = "Composable command line interface toolkit"
-groups = ["default", "dev"]
+groups = ["dev"]
 dependencies = [
     "colorama; platform_system == \"Windows\"",
 ]
@@ -146,7 +146,7 @@ name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
-groups = ["default", "dev"]
+groups = ["dev"]
 marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
@@ -560,17 +560,6 @@ dependencies = [
 files = [
     {file = "gunicorn-21.2.0-py3-none-any.whl", hash = "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0"},
     {file = "gunicorn-21.2.0.tar.gz", hash = "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"},
-]
-
-[[package]]
-name = "h11"
-version = "0.14.0"
-requires_python = ">=3.7"
-summary = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-groups = ["default"]
-files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
 ]
 
 [[package]]
@@ -1278,22 +1267,6 @@ groups = ["default"]
 files = [
     {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
     {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
-]
-
-[[package]]
-name = "uvicorn"
-version = "0.29.0"
-requires_python = ">=3.8"
-summary = "The lightning-fast ASGI server."
-groups = ["default"]
-dependencies = [
-    "click>=7.0",
-    "h11>=0.8",
-    "typing-extensions>=4.0; python_version < \"3.11\"",
-]
-files = [
-    {file = "uvicorn-0.29.0-py3-none-any.whl", hash = "sha256:2c2aac7ff4f4365c206fd773a39bf4ebd1047c238f8b8268ad996829323473de"},
-    {file = "uvicorn-0.29.0.tar.gz", hash = "sha256:6a69214c0b6a087462412670b3ef21224fa48cae0e452b5883e8e8bdfdd11dd0"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "premailer<4.0.0,>=3.10.0",
     "django-braces<2.0.0,>=1.15.0",
     "openpyxl<4.0.0,>=3.1.1",
-    "uvicorn>=0.29.0",
 ]
 
 [tool.pdm.dev-dependencies]


### PR DESCRIPTION
Newer versions of Gunicorn don't need the Uvicorn/DigitalOcean workaround, and it's one more thing to maintain (not to mention it doesn't like restarting cleanly). Remove it.

Closes #141 